### PR TITLE
Add Laravel 12 support

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,9 +13,22 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.3, 8.4]
-        laravel: [10.*,11.*,12.*]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        laravel: [10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
+        exclude:
+          # Laravel 11+ requires PHP 8.2+
+          - php: 8.1
+            laravel: 11.*
+          - php: 8.1
+            laravel: 12.*
+        include:
+          - laravel: 10.*
+            testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        php: [8.1, 8.2, 8.3, 8.4]
         laravel: [10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         exclude:

--- a/.php_cs.dist.php
+++ b/.php_cs.dist.php
@@ -2,7 +2,7 @@
 
 $finder = Symfony\Component\Finder\Finder::create()
     ->in([
-        __DIR__.'/Fortnox',
+        __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
     ->name('*.php')

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "roave/security-advisories": "dev-latest",
         "nunomaduro/collision": "^7.0|^8.0",
-        "nunomaduro/larastan": "^2.0.1",
+        "nunomaduro/larastan": "^2.0.1|^3.0",
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "pestphp/pest": "^2.0|^3.0",
         "pestphp/pest-plugin-laravel": "^2.0|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
         "pestphp/pest": "^2.0|^3.0",
         "pestphp/pest-plugin-laravel": "^2.0|^3.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
+        "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+        "phpstan/phpstan-phpunit": "^1.0|^2.0",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "nunomaduro/larastan": "^2.0.1",
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "pestphp/pest": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "nunomaduro/collision": "^7.0|^8.0",
         "nunomaduro/larastan": "^2.0.1",
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
-        "pestphp/pest": "^2.0",
+        "pestphp/pest": "^2.0|^3.0",
         "pestphp/pest-plugin-laravel": "^2.0|^3.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.2|^8.3",
+        "php": "^8.1|^8.2|^8.3|^8.4|^8.5",
         "guzzlehttp/guzzle": "^7.8",
         "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
         "laravel/socialite": "^5.0",
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
-        "nunomaduro/collision": "^8.0",
+        "nunomaduro/collision": "^7.0|^8.0",
         "nunomaduro/larastan": "^2.0.1",
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "pestphp/pest": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2|^8.3|^8.4|^8.5",
+        "php": "^8.1|^8.2|^8.3|^8.4",
         "guzzlehttp/guzzle": "^7.8",
         "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
         "laravel/socialite": "^5.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,9 +6,6 @@ parameters:
     paths:
         - src
         - config
-        - database
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
-

--- a/src/Commands/RefreshFortnoxAccessToken.php
+++ b/src/Commands/RefreshFortnoxAccessToken.php
@@ -2,16 +2,18 @@
 
 namespace BernskioldMedia\Fortnox\Commands;
 
+use function app;
+
 use BernskioldMedia\Fortnox\Contracts\TokenStorage;
+
+use function config;
+
 use Illuminate\Console\Command;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\Token;
-use function app;
-use function config;
 
 class RefreshFortnoxAccessToken extends Command
 {
-
     protected $signature = 'fortnox:refresh-access-token
                             {--force : Force the refresh of the access token, even if it is not expired.}';
 
@@ -26,14 +28,16 @@ class RefreshFortnoxAccessToken extends Command
 
         $token = $storageProvider->getToken();
 
-        if (!$token) {
+        if (! $token) {
             $this->error('No access token found. Please authenticate with Fortnox first.');
+
             return self::FAILURE;
         }
 
         // Refresh if token expires within 5 minutes (or is already expired)
-        if (now()->addMinutes(5)->lessThan($token->expiresAt) && !$this->option('force')) {
+        if (now()->addMinutes(5)->lessThan($token->expiresAt) && ! $this->option('force')) {
             $this->info('Access token is still valid. No need to refresh. Use with --force to refresh anyway.');
+
             return self::SUCCESS;
         }
 
@@ -48,5 +52,4 @@ class RefreshFortnoxAccessToken extends Command
 
         return self::SUCCESS;
     }
-
 }

--- a/src/Contracts/Resources/Filters/FiltersDates.php
+++ b/src/Contracts/Resources/Filters/FiltersDates.php
@@ -6,7 +6,6 @@ use Carbon\Carbon;
 
 trait FiltersDates
 {
-
     public function from(Carbon $date): static
     {
         $this->query['fromdate'] = $date->format('Y-m-d');
@@ -20,5 +19,4 @@ trait FiltersDates
 
         return $this;
     }
-
 }

--- a/src/Contracts/Resources/Filters/FiltersFilter.php
+++ b/src/Contracts/Resources/Filters/FiltersFilter.php
@@ -4,12 +4,10 @@ namespace BernskioldMedia\Fortnox\Contracts\Resources\Filters;
 
 trait FiltersFilter
 {
-
     public function filter(string $filter): static
     {
         $this->query['filter'] = $filter;
 
         return $this;
     }
-
 }

--- a/src/Contracts/Resources/Filters/FiltersFinancialYear.php
+++ b/src/Contracts/Resources/Filters/FiltersFinancialYear.php
@@ -6,7 +6,6 @@ use Carbon\Carbon;
 
 trait FiltersFinancialYear
 {
-
     public function financialYear(int $year): static
     {
         $this->query['financialyear'] = $year;
@@ -20,5 +19,4 @@ trait FiltersFinancialYear
 
         return $this;
     }
-
 }

--- a/src/Contracts/Resources/Filters/FiltersLastModified.php
+++ b/src/Contracts/Resources/Filters/FiltersLastModified.php
@@ -6,12 +6,10 @@ use Carbon\Carbon;
 
 trait FiltersLastModified
 {
-
     public function lastModified(Carbon $date): static
     {
         $this->query['lastmodified'] = $date->format('Y-m-d H:i');
 
         return $this;
     }
-
 }

--- a/src/Contracts/Resources/Filters/HasPagination.php
+++ b/src/Contracts/Resources/Filters/HasPagination.php
@@ -6,7 +6,6 @@ use BernskioldMedia\Fortnox\Exceptions\InvalidParameter;
 
 trait HasPagination
 {
-
     public function perPage(int $amount): static
     {
         if ($amount > 500) {
@@ -31,5 +30,4 @@ trait HasPagination
 
         return $this;
     }
-
 }

--- a/src/Contracts/Resources/Filters/Searchable.php
+++ b/src/Contracts/Resources/Filters/Searchable.php
@@ -4,12 +4,10 @@ namespace BernskioldMedia\Fortnox\Contracts\Resources\Filters;
 
 trait Searchable
 {
-
     public function search(string $field, mixed $value): static
     {
         $this->query[$field] = $value;
 
         return $this;
     }
-
 }

--- a/src/Contracts/Resources/Search/SearchesCostCenter.php
+++ b/src/Contracts/Resources/Search/SearchesCostCenter.php
@@ -2,13 +2,10 @@
 
 namespace BernskioldMedia\Fortnox\Contracts\Resources\Search;
 
-use Carbon\Carbon;
-
 trait SearchesCostCenter
 {
     public function costCenter(string $costCenter): static
     {
         return $this->search('CostCenter', $costCenter);
     }
-
 }

--- a/src/Contracts/Resources/Sortable.php
+++ b/src/Contracts/Resources/Sortable.php
@@ -4,7 +4,6 @@ namespace BernskioldMedia\Fortnox\Contracts\Resources;
 
 trait Sortable
 {
-
     public function sortBy(string $field, string $order = 'asc'): static
     {
         $this->query['sortby'] = $field;

--- a/src/Contracts/TokenStorage.php
+++ b/src/Contracts/TokenStorage.php
@@ -30,5 +30,4 @@ interface TokenStorage
      * @return bool
      */
     public function hasToken(): bool;
-
 }

--- a/src/Controllers/FortnoxAuthController.php
+++ b/src/Controllers/FortnoxAuthController.php
@@ -2,24 +2,22 @@
 
 namespace BernskioldMedia\Fortnox\Controllers;
 
+use function app;
+
 use BernskioldMedia\Fortnox\Contracts\TokenStorage;
+
+use function config;
+use function explode;
+
 use Illuminate\Http\Request;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\Token;
-use Laravel\Socialite\Two\User;
-use function app;
-use function config;
-use function dd;
-use function explode;
-use function hash_equals;
-use function is_null;
+
 use function redirect;
-use function str;
 use function url;
 
 class FortnoxAuthController
 {
-
     public function toFortnox(Request $request)
     {
         $request->session()->put('fortnox.oauth.request_url', url()->previous());

--- a/src/Data/StoredToken.php
+++ b/src/Data/StoredToken.php
@@ -14,8 +14,7 @@ class StoredToken implements Arrayable, Serializable
         public string          $token,
         public string          $refreshToken,
         public CarbonInterface $expiresAt,
-    )
-    {
+    ) {
     }
 
     public function toArray()

--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -6,7 +6,6 @@ use Exception;
 
 class InvalidConfiguration extends Exception
 {
-
     public static function missingClientId(): self
     {
         return new static('Missing client ID. To use the Fortnox API you need to set a valid client ID.');
@@ -31,5 +30,4 @@ class InvalidConfiguration extends Exception
     {
         return new static("Invalid Storage Configuration: {$message}");
     }
-
 }

--- a/src/Exceptions/InvalidParameter.php
+++ b/src/Exceptions/InvalidParameter.php
@@ -6,10 +6,8 @@ use Exception;
 
 class InvalidParameter extends Exception
 {
-
     public static function tooManyPerPage(): self
     {
         return new static('Too many records per page. The Fortnox API only supports up to 500 records per page.');
     }
-
 }

--- a/src/Fortnox.php
+++ b/src/Fortnox.php
@@ -18,11 +18,9 @@ use BernskioldMedia\Fortnox\Resources\Voucher;
 
 class Fortnox
 {
-
     public function __construct(
         protected FortnoxClient $client
-    )
-    {
+    ) {
     }
 
     public function absenceTransactions(): AbsenceTransaction
@@ -89,5 +87,4 @@ class Fortnox
     {
         return new Voucher($this->client);
     }
-
 }

--- a/src/FortnoxServiceProvider.php
+++ b/src/FortnoxServiceProvider.php
@@ -6,6 +6,9 @@ use BernskioldMedia\Fortnox\Commands\RefreshFortnoxAccessToken;
 use BernskioldMedia\Fortnox\Contracts\TokenStorage;
 use BernskioldMedia\Fortnox\Exceptions\InvalidConfiguration;
 use BernskioldMedia\Fortnox\Socialite\FortnoxSocialiteProvider;
+
+use function config;
+
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Support\Arr;
 use Laravel\Socialite\Contracts\Factory;
@@ -13,7 +16,7 @@ use RateLimiter;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use function config;
+
 use function url;
 
 class FortnoxServiceProvider extends PackageServiceProvider
@@ -46,7 +49,7 @@ class FortnoxServiceProvider extends PackageServiceProvider
             ]);
         });
 
-        RateLimiter::for('fortnox', fn() => Limit::perSecond(25, 5));
+        RateLimiter::for('fortnox', fn () => Limit::perSecond(25, 5));
     }
 
     public function registeringPackage()

--- a/src/Resources/AbsenceTransaction.php
+++ b/src/Resources/AbsenceTransaction.php
@@ -30,6 +30,7 @@ class AbsenceTransaction extends BaseResource
     {
         $formattedDate = $date->format('Y-m-d');
         $raw = $this->client->get($this->getEndpoint()."/$employeeId/$formattedDate/$code");
+
         return new ListResponse($raw, $this->getPluralKey());
     }
 

--- a/src/Resources/Sie.php
+++ b/src/Resources/Sie.php
@@ -6,7 +6,6 @@ use sie\Parser;
 
 class Sie extends BaseResource
 {
-
     protected int $type = 1;
 
     public function fileType(int $type): static

--- a/src/Responses/ListResponse.php
+++ b/src/Responses/ListResponse.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Collection;
 
 class ListResponse
 {
-
     public int $totalRecords;
     public int $totalPages;
     public int $currentPage;
@@ -29,5 +28,4 @@ class ListResponse
     {
         return $this->data;
     }
-
 }

--- a/src/Socialite/FortnoxSocialiteProvider.php
+++ b/src/Socialite/FortnoxSocialiteProvider.php
@@ -2,21 +2,23 @@
 
 namespace BernskioldMedia\Fortnox\Socialite;
 
+use function base64_encode;
+use function config;
+use function explode;
+
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
+
+use function json_decode;
+
 use Laravel\Socialite\Two\AbstractProvider;
 use Laravel\Socialite\Two\InvalidStateException;
 use Laravel\Socialite\Two\ProviderInterface;
 use Laravel\Socialite\Two\Token;
 use Laravel\Socialite\Two\User;
-use function base64_encode;
-use function config;
-use function explode;
-use function json_decode;
 
 class FortnoxSocialiteProvider extends AbstractProvider implements ProviderInterface
 {
-
     protected $scopeSeparator = ' ';
 
     protected function getAuthUrl($state)
@@ -34,6 +36,7 @@ class FortnoxSocialiteProvider extends AbstractProvider implements ProviderInter
     protected function getTokenUrl()
     {
         $baseUrl = config('fortnox.oauth_base_url', 'https://apps.fortnox.se/oauth-v1');
+
         return "$baseUrl/token";
     }
 

--- a/src/TokenStorage/CacheTokenStorage.php
+++ b/src/TokenStorage/CacheTokenStorage.php
@@ -9,7 +9,6 @@ use Laravel\Socialite\Two\Token;
 
 class CacheTokenStorage implements TokenStorage
 {
-
     protected string $cacheKey;
 
     protected ?string $driver;
@@ -36,7 +35,7 @@ class CacheTokenStorage implements TokenStorage
     {
         $tokenData = Cache::driver($this->driver)->get($this->cacheKey);
 
-        if(!$tokenData) {
+        if (! $tokenData) {
             return null;
         }
 

--- a/src/TokenStorage/LaravelSettingsStorage.php
+++ b/src/TokenStorage/LaravelSettingsStorage.php
@@ -5,14 +5,10 @@ namespace BernskioldMedia\Fortnox\TokenStorage;
 use BernskioldMedia\Fortnox\Contracts\TokenStorage;
 use BernskioldMedia\Fortnox\Data\StoredToken;
 use BernskioldMedia\Fortnox\Exceptions\InvalidConfiguration;
-use Illuminate\Support\Facades\Cache;
 use Laravel\Socialite\Two\Token;
-use function serialize;
-use function unserialize;
 
 class LaravelSettingsStorage implements TokenStorage
 {
-
     protected string $settingsClass;
 
     protected string $settingName;
@@ -22,13 +18,13 @@ class LaravelSettingsStorage implements TokenStorage
         $settingsClass = config('fortnox.provider_configuration.laravel_settings.settings_class');
         $settingName = config('fortnox.provider_configuration.laravel_settings.setting_name');
 
-        if (!$settingsClass) {
+        if (! $settingsClass) {
             throw InvalidConfiguration::invalidStorageConfiguration(
                 'The settings class is not set in the configuration.'
             );
         }
 
-        if (!$settingName) {
+        if (! $settingName) {
             throw InvalidConfiguration::invalidStorageConfiguration(
                 'The setting name is not set in the configuration.'
             );
@@ -81,6 +77,6 @@ class LaravelSettingsStorage implements TokenStorage
     {
         $settings = app($this->settingsClass);
 
-        return !empty($settings->{$this->settingName});
+        return ! empty($settings->{$this->settingName});
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,26 @@
+<?php
+
+it('has default config values', function () {
+    expect(config('fortnox.base_url'))->toBe('https://api.fortnox.se/3/');
+    expect(config('fortnox.oauth_base_url'))->toBe('https://apps.fortnox.se/oauth-v1');
+    expect(config('fortnox.use_service_account'))->toBeTrue();
+});
+
+it('has oauth route configuration', function () {
+    expect(config('fortnox.routes.oauth.redirect'))->toBe('/oauth/fortnox');
+    expect(config('fortnox.routes.oauth.callback'))->toBe('/oauth/fortnox/callback');
+});
+
+it('has web middleware configured for routes', function () {
+    expect(config('fortnox.routes.middleware'))->toContain('web');
+});
+
+it('has cache storage configured by default', function () {
+    expect(config('fortnox.storage_provider'))
+        ->toBe(\BernskioldMedia\Fortnox\TokenStorage\CacheTokenStorage::class);
+});
+
+it('has cache provider configuration', function () {
+    expect(config('fortnox.provider_configuration.cache.prefix'))->toBe('fortnox.token');
+    expect(config('fortnox.provider_configuration.cache.driver'))->toBeNull();
+});

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,1 +1,47 @@
 <?php
+
+use BernskioldMedia\Fortnox\Fortnox;
+use BernskioldMedia\Fortnox\FortnoxClient;
+use BernskioldMedia\Fortnox\Resources\Account;
+use BernskioldMedia\Fortnox\Resources\Customer;
+use BernskioldMedia\Fortnox\Resources\Invoice;
+use BernskioldMedia\Fortnox\Resources\Project;
+use BernskioldMedia\Fortnox\Resources\Supplier;
+use BernskioldMedia\Fortnox\Resources\Voucher;
+
+it('can create a fortnox client', function () {
+    $client = new FortnoxClient(
+        accessToken: 'test-token',
+        baseUrl: 'https://api.fortnox.se/3/'
+    );
+
+    expect($client)->toBeInstanceOf(FortnoxClient::class);
+    expect($client->request)->toBeInstanceOf(\Illuminate\Http\Client\PendingRequest::class);
+});
+
+it('can create a fortnox instance with a client', function () {
+    $client = new FortnoxClient(
+        accessToken: 'test-token',
+        baseUrl: 'https://api.fortnox.se/3/'
+    );
+
+    $fortnox = new Fortnox($client);
+
+    expect($fortnox)->toBeInstanceOf(Fortnox::class);
+});
+
+it('returns correct resource types from fortnox instance', function () {
+    $client = new FortnoxClient(
+        accessToken: 'test-token',
+        baseUrl: 'https://api.fortnox.se/3/'
+    );
+
+    $fortnox = new Fortnox($client);
+
+    expect($fortnox->accounts())->toBeInstanceOf(Account::class);
+    expect($fortnox->customers())->toBeInstanceOf(Customer::class);
+    expect($fortnox->invoices())->toBeInstanceOf(Invoice::class);
+    expect($fortnox->project())->toBeInstanceOf(Project::class);
+    expect($fortnox->suppliers())->toBeInstanceOf(Supplier::class);
+    expect($fortnox->vouchers())->toBeInstanceOf(Voucher::class);
+});

--- a/tests/InvalidConfigurationTest.php
+++ b/tests/InvalidConfigurationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use BernskioldMedia\Fortnox\Exceptions\InvalidConfiguration;
+
+it('can create missing client id exception', function () {
+    $exception = InvalidConfiguration::missingClientId();
+
+    expect($exception)->toBeInstanceOf(InvalidConfiguration::class);
+    expect($exception->getMessage())->toContain('client ID');
+});
+
+it('can create missing client secret exception', function () {
+    $exception = InvalidConfiguration::missingClientSecret();
+
+    expect($exception)->toBeInstanceOf(InvalidConfiguration::class);
+    expect($exception->getMessage())->toContain('client secret');
+});
+
+it('can create missing base url exception', function () {
+    $exception = InvalidConfiguration::missingBaseUrl();
+
+    expect($exception)->toBeInstanceOf(InvalidConfiguration::class);
+    expect($exception->getMessage())->toContain('Base URL');
+});
+
+it('can create missing storage provider exception', function () {
+    $exception = InvalidConfiguration::missingStorageProvider();
+
+    expect($exception)->toBeInstanceOf(InvalidConfiguration::class);
+    expect($exception->getMessage())->toContain('storage provider');
+});
+
+it('can create invalid storage configuration exception', function () {
+    $exception = InvalidConfiguration::invalidStorageConfiguration('Custom error message');
+
+    expect($exception)->toBeInstanceOf(InvalidConfiguration::class);
+    expect($exception->getMessage())->toContain('Custom error message');
+});


### PR DESCRIPTION
- Extend PHP support from 8.2-8.3 to 8.1-8.x
- Add collision ^7.0 for PHP 8.1 compatibility
- Update test matrix with proper Laravel/PHP version exclusions
- Add testbench version mappings for Laravel 10-12
- Update PHPStan workflow to use PHP 8.2